### PR TITLE
fix missing padding in secrets

### DIFF
--- a/hotp/hotp.go
+++ b/hotp/hotp.go
@@ -70,6 +70,12 @@ func GenerateCode(secret string, counter uint64) (string, error) {
 // GenerateCodeCustom uses a counter and secret value and options struct to
 // create a passcode.
 func GenerateCodeCustom(secret string, counter uint64, opts ValidateOpts) (passcode string, err error) {
+	// As noted in issue #10 this adds support for TOTP secrets that are
+	// missing their padding.
+	if n := len(secret) % 8; n != 0 {
+		secret = secret + strings.Repeat("=", 8-n)
+	}
+
 	secretBytes, err := base32.StdEncoding.DecodeString(secret)
 	if err != nil {
 		return "", otp.ErrValidateSecretInvalidBase32


### PR DESCRIPTION
This is a PR for the fix made by @Luzifer in issue #10 

I ran into this issue today as well and patched it locally for my app, however I also believe it makes sense to have this in the library.