### PR TITLE
Add otp.key.URL() method

### DIFF
--- a/otp.go
+++ b/otp.go
@@ -138,6 +138,11 @@ func (k *Key) Secret() string {
 	return q.Get("secret")
 }
 
+// URL returns the OTP URL as a string
+func (k *Key) URL() string {
+	return k.url.String()
+}
+
 // Algorithm represents the hashing function to use in the HMAC
 // operation needed for OTPs.
 type Algorithm int


### PR DESCRIPTION
Hey there, thank you for this library :smile:  I've added a simple method to retrieve a key's URL string which can be subsequently consumed by NewKeyFromURL(). I found having the URL string helps with maintaining state between some views.