### PR TITLE
Increase default TOTP secret size to 20 bytes

### DIFF
--- a/totp/totp.go
+++ b/totp/totp.go
@@ -136,7 +136,7 @@ type GenerateOpts struct {
 	AccountName string
 	// Number of seconds a TOTP hash is valid for. Defaults to 30 seconds.
 	Period uint
-	// Size in size of the generated Secret. Defaults to 10 bytes.
+	// Size in size of the generated Secret. Defaults to 20 bytes.
 	SecretSize uint
 	// Digits to request. Defaults to 6.
 	Digits otp.Digits
@@ -160,7 +160,7 @@ func Generate(opts GenerateOpts) (*otp.Key, error) {
 	}
 
 	if opts.SecretSize == 0 {
-		opts.SecretSize = 10
+		opts.SecretSize = 20
 	}
 
 	if opts.Digits == 0 {

--- a/totp/totp_test.go
+++ b/totp/totp_test.go
@@ -126,7 +126,7 @@ func TestGenerate(t *testing.T) {
 	require.NoError(t, err, "generate basic TOTP")
 	require.Equal(t, "SnakeOil", k.Issuer(), "Extracting Issuer")
 	require.Equal(t, "alice@example.com", k.AccountName(), "Extracting Account Name")
-	require.Equal(t, 16, len(k.Secret()), "Secret is 16 bytes long as base32.")
+	require.Equal(t, 32, len(k.Secret()), "Secret is 32 bytes long as base32.")
 
 	k, err = Generate(GenerateOpts{
 		Issuer:      "SnakeOil",


### PR DESCRIPTION
Although Google has recommended 10 bytes, this may be prone to brute-force attacks and the RFC itself suggests 20 bytes. This simply changes the default secret size to match that.

I also made a PR to gitea (go-gitea/gitea#4287), where I increased the default to 40. That PR also contains more motivation.