### PR TITLE
base32: properly handle unused padding characters

### DIFF
--- a/hotp/hotp.go
+++ b/hotp/hotp.go
@@ -70,12 +70,7 @@ func GenerateCode(secret string, counter uint64) (string, error) {
 // GenerateCodeCustom uses a counter and secret value and options struct to
 // create a passcode.
 func GenerateCodeCustom(secret string, counter uint64, opts ValidateOpts) (passcode string, err error) {
-	// As noted in issue #10 and #17 this adds support for TOTP secrets that are
-	// missing their padding.
 	secret = strings.TrimSpace(secret)
-	if n := len(secret) % 8; n != 0 {
-		secret = secret + strings.Repeat("=", 8-n)
-	}
 
 	// As noted in issue #24 Google has started producing base32 in lower case,
 	// but the StdEncoding (and the RFC), expect a dictionary of only upper case letters.

--- a/hotp/hotp.go
+++ b/hotp/hotp.go
@@ -81,7 +81,7 @@ func GenerateCodeCustom(secret string, counter uint64, opts ValidateOpts) (passc
 	// but the StdEncoding (and the RFC), expect a dictionary of only upper case letters.
 	secret = strings.ToUpper(secret)
 
-	secretBytes, err := base32.StdEncoding.DecodeString(secret)
+	secretBytes, err := base32.StdEncoding.WithPadding(base32.NoPadding).DecodeString(secret)
 	if err != nil {
 		return "", otp.ErrValidateSecretInvalidBase32
 	}
@@ -180,7 +180,7 @@ func Generate(opts GenerateOpts) (*otp.Key, error) {
 		return nil, err
 	}
 
-	v.Set("secret", strings.TrimRight(base32.StdEncoding.EncodeToString(secret), "="))
+	v.Set("secret", base32.StdEncoding.WithPadding(base32.NoPadding).EncodeToString(secret))
 	v.Set("issuer", opts.Issuer)
 	v.Set("algorithm", opts.Algorithm.String())
 	v.Set("digits", opts.Digits.String())

--- a/hotp/hotp_test.go
+++ b/hotp/hotp_test.go
@@ -34,7 +34,7 @@ type tc struct {
 }
 
 var (
-	secSha1 = base32.StdEncoding.EncodeToString([]byte("12345678901234567890"))
+	secSha1 = base32.StdEncoding.WithPadding(base32.NoPadding).EncodeToString([]byte("12345678901234567890"))
 
 	rfcMatrixTCs = []tc{
 		{0, "755224", otp.AlgorithmSHA1, secSha1},
@@ -79,7 +79,7 @@ func TestGenerateRFCMatrix(t *testing.T) {
 }
 
 func TestValidateInvalid(t *testing.T) {
-	secSha1 := base32.StdEncoding.EncodeToString([]byte("12345678901234567890"))
+	secSha1 := base32.StdEncoding.WithPadding(base32.NoPadding).EncodeToString([]byte("12345678901234567890"))
 
 	valid, err := ValidateCustom("foo", 11, secSha1,
 		ValidateOpts{

--- a/totp/totp.go
+++ b/totp/totp.go
@@ -18,8 +18,6 @@
 package totp
 
 import (
-	"strings"
-
 	"github.com/pquerna/otp"
 	"github.com/pquerna/otp/hotp"
 
@@ -176,7 +174,7 @@ func Generate(opts GenerateOpts) (*otp.Key, error) {
 		return nil, err
 	}
 
-	v.Set("secret", strings.TrimRight(base32.StdEncoding.EncodeToString(secret), "="))
+	v.Set("secret", base32.StdEncoding.WithPadding(base32.NoPadding).EncodeToString(secret))
 	v.Set("issuer", opts.Issuer)
 	v.Set("period", strconv.FormatUint(uint64(opts.Period), 10))
 	v.Set("algorithm", opts.Algorithm.String())

--- a/totp/totp_test.go
+++ b/totp/totp_test.go
@@ -35,9 +35,9 @@ type tc struct {
 }
 
 var (
-	secSha1   = base32.StdEncoding.EncodeToString([]byte("12345678901234567890"))
-	secSha256 = base32.StdEncoding.EncodeToString([]byte("12345678901234567890123456789012"))
-	secSha512 = base32.StdEncoding.EncodeToString([]byte("1234567890123456789012345678901234567890123456789012345678901234"))
+	secSha1   = base32.StdEncoding.WithPadding(base32.NoPadding).EncodeToString([]byte("12345678901234567890"))
+	secSha256 = base32.StdEncoding.WithPadding(base32.NoPadding).EncodeToString([]byte("12345678901234567890123456789012"))
+	secSha512 = base32.StdEncoding.WithPadding(base32.NoPadding).EncodeToString([]byte("1234567890123456789012345678901234567890123456789012345678901234"))
 
 	rfcMatrixTCs = []tc{
 		{59, "94287082", otp.AlgorithmSHA1, secSha1},
@@ -96,7 +96,7 @@ func TestGenerateRFCTCs(t *testing.T) {
 }
 
 func TestValidateSkew(t *testing.T) {
-	secSha1 := base32.StdEncoding.EncodeToString([]byte("12345678901234567890"))
+	secSha1 := base32.StdEncoding.WithPadding(base32.NoPadding).EncodeToString([]byte("12345678901234567890"))
 
 	tests := []tc{
 		{29, "94287082", otp.AlgorithmSHA1, secSha1},


### PR DESCRIPTION
Fixes decoding error for data that requires padding such as FODCQXJNS25PVCI4EYCA.