### PR TITLE
use options keeps users from choosing between Validate/ValidateCustom and Generate/GenerateCustom

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,9 @@
+kind: pipeline
+name: default
+type: docker
+
+steps:
+  - name: test
+    image: golang:1.16
+    commands:
+      - go test ./...

--- a/.drone.yml
+++ b/.drone.yml
@@ -7,3 +7,12 @@ steps:
     image: golang:1.16
     commands:
       - go test ./...
+      - go test -v -coverprofile=coverage.txt -covermode=atomic ./...
+
+  - name: coverage
+    image: plugins/codecov
+    settings:
+      token:
+        from_secret: codecov-token
+      files:
+        - coverage.txt

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# .gitignore
+.drone.yml

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-# .gitignore
+.gitignore
 .drone.yml

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # otp: One Time Password utilities Go / Golang
 
-[![PkgGoDev](https://pkg.go.dev/badge/github.com/pquerna/otp)](https://pkg.go.dev/github.com/pquerna/otp) [![Build Status](https://travis-ci.org/pquerna/otp.svg?branch=master)](https://travis-ci.org/pquerna/otp)
+[![PkgGoDev](https://pkg.go.dev/badge/github.com/pquerna/otp)](https://pkg.go.dev/github.com/pquerna/otp) [![Build Status](https://travis-ci.org/pquerna/otp.svg?branch=master)](https://travis-ci.org/pquerna/otp) [![codecov](https://codecov.io/gh/d-fal/otp/branch/master/graph/badge.svg?token=X1W4OD9E8T)](https://codecov.io/gh/d-fal/otp)
 
 # Why One Time Passwords?
 

--- a/examples/custom_totp_generation/main.go
+++ b/examples/custom_totp_generation/main.go
@@ -1,8 +1,0 @@
-package main
-
-/*
- In this example, we want to show the definition of custom-generated totp
-*/
-func main() {
-
-}

--- a/examples/otp_api_v1/main.go
+++ b/examples/otp_api_v1/main.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"github.com/pquerna/otp"
+	"github.com/pquerna/otp/totp"
+
+	"bufio"
+	"bytes"
+	"encoding/base32"
+	"fmt"
+	"image/png"
+	"io/ioutil"
+	"os"
+	"time"
+)
+
+func display(key *otp.Key, data []byte) {
+	fmt.Printf("Issuer:       %s\n", key.Issuer())
+	fmt.Printf("Account Name: %s\n", key.AccountName())
+	fmt.Printf("Secret:       %s\n", key.Secret())
+	fmt.Println("Writing PNG to qr-code.png....")
+	ioutil.WriteFile("qr-code.png", data, 0644)
+	fmt.Println("")
+	fmt.Println("Please add your TOTP to your OTP Application now!")
+	fmt.Println("")
+}
+
+func promptForPasscode() string {
+	reader := bufio.NewReader(os.Stdin)
+	fmt.Print("Enter Passcode: ")
+	text, _ := reader.ReadString('\n')
+	return text
+}
+
+// Demo function, not used in main
+// Generates Passcode using a UTF-8 (not base32) secret and custom paramters
+func GeneratePassCode(utf8string string) string {
+	secret := base32.StdEncoding.EncodeToString([]byte(utf8string))
+	passcode, err := totp.GenerateCodeCustom(secret, time.Now(), totp.ValidateOpts{
+		Period:    30,
+		Skew:      1,
+		Digits:    otp.DigitsSix,
+		Algorithm: otp.AlgorithmSHA512,
+	})
+	if err != nil {
+		panic(err)
+	}
+	return passcode
+}
+
+func main() {
+	key, err := totp.Generate(totp.GenerateOpts{
+		Issuer:      "Example.com",
+		AccountName: "alice@example.com",
+	})
+	if err != nil {
+		panic(err)
+	}
+	// Convert TOTP key into a PNG
+	var buf bytes.Buffer
+	img, err := key.Image(200, 200)
+	if err != nil {
+		panic(err)
+	}
+	png.Encode(&buf, img)
+
+	// display the QR code to the user.
+	display(key, buf.Bytes())
+
+	// Now Validate that the user's successfully added the passcode.
+	fmt.Println("Validating TOTP...")
+	passcode := promptForPasscode()
+	valid := totp.Validate(passcode, key.Secret())
+	if valid {
+		println("Valid passcode!")
+		os.Exit(0)
+	} else {
+		println("Invalid passcode!")
+		os.Exit(1)
+	}
+}

--- a/examples/otp_api_v2/main.go
+++ b/examples/otp_api_v2/main.go
@@ -11,7 +11,6 @@ import (
 	"image/png"
 	"io/ioutil"
 	"os"
-	"time"
 )
 
 func display(key *otp.Key, data []byte) {
@@ -36,7 +35,7 @@ func promptForPasscode() string {
 // Generates Passcode using a UTF-8 (not base32) secret and custom paramters
 func GeneratePassCode(utf8string string) string {
 	secret := base32.StdEncoding.EncodeToString([]byte(utf8string))
-	passcode, err := totp.GenerateCodeWithOpts(secret, time.Now(),
+	passcode, err := totp.GenerateCodeWithOpts(secret,
 		totp.WithAlgorithm(otp.AlgorithmSHA512), totp.WithDigits(otp.DigitsSix),
 		totp.WithPeriod(30), totp.WithSkew(30))
 	if err != nil {

--- a/examples/otp_api_v2/main.go
+++ b/examples/otp_api_v2/main.go
@@ -36,7 +36,7 @@ func promptForPasscode() string {
 // Generates Passcode using a UTF-8 (not base32) secret and custom paramters
 func GeneratePassCode(utf8string string) string {
 	secret := base32.StdEncoding.EncodeToString([]byte(utf8string))
-	passcode, err := totp.GenerateCodeCustom(secret, time.Now(),
+	passcode, err := totp.GenerateCodeWithOpts(secret, time.Now(),
 		totp.WithAlgorithm(otp.AlgorithmSHA512), totp.WithDigits(otp.DigitsSix),
 		totp.WithPeriod(30), totp.WithSkew(30))
 	if err != nil {
@@ -46,9 +46,11 @@ func GeneratePassCode(utf8string string) string {
 }
 
 func main() {
-	key, err := totp.Generate(
-		totp.WithIssuer("Example.com"),
-		totp.WithAccountName("alice@example.com"),
+	key, err := totp.GenerateWithOpts(
+		totp.WithIssuer("api.v2.otp"),
+		totp.WithAccountName("bob@example.com"),
+		totp.WithGenDigits(otp.DigitsSix),
+		totp.WithGenPeriod(60),
 	)
 	if err != nil {
 		panic(err)

--- a/hotp/hotp.go
+++ b/hotp/hotp.go
@@ -31,8 +31,6 @@ import (
 	"math"
 	"net/url"
 	"strings"
-
-	"github.com/pquerna/otp"
 )
 
 const debug = false

--- a/hotp/hotp.go
+++ b/hotp/hotp.go
@@ -18,8 +18,9 @@
 package hotp
 
 import (
-	"github.com/pquerna/otp"
 	"io"
+
+	"github.com/pquerna/otp"
 
 	"crypto/hmac"
 	"crypto/rand"
@@ -60,7 +61,7 @@ type ValidateOpts struct {
 
 // GenerateCode creates a HOTP passcode given a counter and secret.
 // This is a shortcut for GenerateCodeCustom, with parameters that
-// are compataible with Google-Authenticator.
+// are compatible with Google-Authenticator.
 func GenerateCode(secret string, counter uint64) (string, error) {
 	return GenerateCodeCustom(secret, counter, ValidateOpts{
 		Digits:    otp.DigitsSix,
@@ -101,6 +102,7 @@ func GenerateCodeCustom(secret string, counter uint64, opts ValidateOpts) (passc
 	// "Dynamic truncation" in RFC 4226
 	// http://tools.ietf.org/html/rfc4226#section-5.4
 	offset := sum[len(sum)-1] & 0xf
+
 	value := int64(((int(sum[offset]) & 0x7f) << 24) |
 		((int(sum[offset+1] & 0xff)) << 16) |
 		((int(sum[offset+2] & 0xff)) << 8) |

--- a/totp/defaults.go
+++ b/totp/defaults.go
@@ -1,0 +1,48 @@
+package totp
+
+import (
+	"crypto/rand"
+
+	"github.com/pquerna/otp"
+)
+
+func (opts *GenerateOpts) defaults() error {
+	if opts.Issuer == "" {
+		return otp.ErrGenerateMissingIssuer
+	}
+
+	if opts.AccountName == "" {
+		return otp.ErrGenerateMissingAccountName
+	}
+
+	if opts.Period == 0 {
+		opts.Period = 30
+	}
+
+	if opts.SecretSize == 0 {
+		opts.SecretSize = 20
+	}
+
+	if opts.Digits == 0 {
+		opts.Digits = otp.DigitsSix
+	}
+
+	if opts.Rand == nil {
+		opts.Rand = rand.Reader
+	}
+
+	return nil
+}
+
+//
+func (opts *ValidateOpts) defaultOpts() {
+	if opts.Skew == 0 {
+		opts.Skew = 1
+	}
+	if opts.Digits == 0 {
+		opts.Digits = otp.DigitsSix
+	}
+	if opts.Period == 0 {
+		opts.Period = 30
+	}
+}

--- a/totp/defaults.go
+++ b/totp/defaults.go
@@ -2,6 +2,7 @@ package totp
 
 import (
 	"crypto/rand"
+	"time"
 
 	"github.com/pquerna/otp"
 )
@@ -34,7 +35,7 @@ func (opts *GenerateOpts) defaults() error {
 	return nil
 }
 
-//
+// defaultOpts sets default opts
 func (opts *ValidateOpts) defaultOpts() {
 	if opts.Skew == 0 {
 		opts.Skew = 1
@@ -44,5 +45,8 @@ func (opts *ValidateOpts) defaultOpts() {
 	}
 	if opts.Period == 0 {
 		opts.Period = 30
+	}
+	if opts.t.IsZero() {
+		opts.t = time.Now()
 	}
 }

--- a/totp/options.go
+++ b/totp/options.go
@@ -1,0 +1,85 @@
+package totp
+
+import (
+	"io"
+
+	"github.com/pquerna/otp"
+)
+
+// GenerateOpts generate opts are the options to be used in
+// generate and validate functions
+type GenerateOpt func(opts *GenerateOpts)
+
+func WithIssuer(issuer string) GenerateOpt {
+	return func(opts *GenerateOpts) {
+		opts.Issuer = issuer
+	}
+}
+
+func WithAccountName(account string) GenerateOpt {
+	return func(opts *GenerateOpts) {
+		opts.AccountName = account
+	}
+}
+
+func WithGenPeriod(period uint) GenerateOpt {
+	return func(opts *GenerateOpts) {
+		opts.Period = period
+	}
+}
+func WithSecret(secret []byte) GenerateOpt {
+	return func(opts *GenerateOpts) {
+		opts.Secret = secret
+	}
+}
+
+func WithGenDigits(digits otp.Digits) GenerateOpt {
+
+	return func(opts *GenerateOpts) {
+		opts.Digits = digits
+	}
+}
+
+func WithGenAlgorithm(algo otp.Algorithm) GenerateOpt {
+	return func(opts *GenerateOpts) {
+		opts.Algorithm = algo
+	}
+}
+
+func WithRandomGenerator(r io.Reader) GenerateOpt {
+	return func(opts *GenerateOpts) {
+		opts.Rand = r
+	}
+}
+
+func WithSecretSize(size uint) GenerateOpt {
+	return func(opts *GenerateOpts) {
+		opts.SecretSize = size
+	}
+}
+
+//
+type ValidateOpt func(opt *ValidateOpts)
+
+func WithPeriod(period uint) ValidateOpt {
+	return func(opt *ValidateOpts) {
+		opt.Period = period
+	}
+}
+func WithSkew(skew uint) ValidateOpt {
+	return func(opt *ValidateOpts) {
+		opt.Skew = skew
+	}
+}
+
+func WithDigits(digits otp.Digits) ValidateOpt {
+	return func(opt *ValidateOpts) {
+		opt.Digits = digits
+	}
+}
+
+func WithAlgorithm(algo otp.Algorithm) ValidateOpt {
+	return func(opt *ValidateOpts) {
+		opt.Algorithm = algo
+	}
+}

--- a/totp/options.go
+++ b/totp/options.go
@@ -2,6 +2,7 @@ package totp
 
 import (
 	"io"
+	"time"
 
 	"github.com/pquerna/otp"
 )
@@ -81,5 +82,11 @@ func WithDigits(digits otp.Digits) ValidateOpt {
 func WithAlgorithm(algo otp.Algorithm) ValidateOpt {
 	return func(opt *ValidateOpts) {
 		opt.Algorithm = algo
+	}
+}
+
+func WithTime(t time.Time) ValidateOpt {
+	return func(opt *ValidateOpts) {
+		opt.t = t
 	}
 }

--- a/totp/totp.go
+++ b/totp/totp.go
@@ -74,6 +74,10 @@ type ValidateOpts struct {
 	Digits otp.Digits
 	// Algorithm to use for HMAC. Defaults to SHA1.
 	Algorithm otp.Algorithm
+	// the time in which we would like to validate our code
+	// in the normal usage, it is equal to current time : time.Now()
+	// but for testing puposes, it could be changed to a later/future time
+	t time.Time
 }
 
 // Deprecated

--- a/totp/totp.go
+++ b/totp/totp.go
@@ -34,12 +34,17 @@ import (
 // Validate a TOTP using the current time.
 // A shortcut for ValidateCustom, Validate uses a configuration
 // that is compatible with Google-Authenticator and most clients.
-func Validate(passcode string, secret string, validateOpts ...ValidateOpt) bool {
+func Validate(passcode string, secret string) bool {
 	rv, _ := ValidateCustom(
 		passcode,
 		secret,
 		time.Now().UTC(),
-		validateOpts...,
+		ValidateOpts{
+			Period:    30,
+			Skew:      1,
+			Digits:    otp.DigitsSix,
+			Algorithm: otp.AlgorithmSHA1,
+		},
 	)
 	return rv
 }
@@ -49,13 +54,12 @@ func Validate(passcode string, secret string, validateOpts ...ValidateOpt) bool 
 // A shortcut for GenerateCodeCustom, GenerateCode uses a configuration
 // that is compatible with Google-Authenticator and most clients.
 func GenerateCode(secret string, t time.Time) (string, error) {
-	return GenerateCodeCustom(secret,
-		t,
-		WithDigits(otp.DigitsSix),
-		WithSkew(1),
-		WithAlgorithm(otp.AlgorithmSHA1),
-		WithPeriod(30),
-	)
+	return GenerateCodeCustom(secret, t, ValidateOpts{
+		Period:    30,
+		Skew:      1,
+		Digits:    otp.DigitsSix,
+		Algorithm: otp.AlgorithmSHA1,
+	})
 }
 
 // ValidateOpts provides options for ValidateCustom().
@@ -157,23 +161,7 @@ func Generate(opts GenerateOpts) (*otp.Key, error) {
 	if err := opts.defaults(); err != nil {
 		return nil, err
 	}
-	return nil
-}
 
-var b32NoPadding = base32.StdEncoding.WithPadding(base32.NoPadding)
-
-// Generate a new TOTP Key.
-func Generate(genOpts ...GenerateOpt) (*otp.Key, error) {
-
-	opts := new(GenerateOpts)
-
-	for _, opt := range genOpts {
-		opt(opts)
-	}
-
-	if err := opts.defaults(); err != nil {
-		return nil, err
-	}
 	// otpauth://totp/Example:alice@google.com?secret=JBSWY3DPEHPK3PXP&issuer=Example
 
 	v := url.Values{}

--- a/totp/totp_opts.go
+++ b/totp/totp_opts.go
@@ -4,7 +4,6 @@ import (
 	"math"
 	"net/url"
 	"strconv"
-	"time"
 
 	"github.com/pquerna/otp"
 	"github.com/pquerna/otp/hotp"
@@ -13,13 +12,13 @@ import (
 // ValidateWithOpts validate with opts
 // it has deprecated Validate and will replace it soon.
 func ValidateWithOpts(passcode, secret string, validateOpts ...ValidateOpt) (bool, error) {
-	return validateCustomOpt(passcode, secret, time.Now(), validateOpts...)
+	return validateCustomOpt(passcode, secret, validateOpts...)
 }
 
 // validateCustomOpt validates a TOTP given a user specified time and custom options.
 // Most users should use Validate() to provide an interpolatable TOTP experience.
 // This replicates ValidateCustomOpt
-func validateCustomOpt(passcode, secret string, t time.Time, validateOpts ...ValidateOpt) (bool, error) {
+func validateCustomOpt(passcode, secret string, validateOpts ...ValidateOpt) (bool, error) {
 
 	opts := new(ValidateOpts)
 
@@ -29,7 +28,7 @@ func validateCustomOpt(passcode, secret string, t time.Time, validateOpts ...Val
 	opts.defaultOpts()
 
 	counters := []uint64{}
-	counter := int64(math.Floor(float64(t.Unix()) / float64(opts.Period)))
+	counter := int64(math.Floor(float64(opts.t.Unix()) / float64(opts.Period)))
 
 	counters = append(counters, uint64(counter))
 	for i := 1; i <= int(opts.Skew); i++ {
@@ -101,7 +100,7 @@ func GenerateWithOpts(genOpts ...GenerateOpt) (*otp.Key, error) {
 // GenerateCodeWithOpts takes a timepoint and produces a passcode using a
 // secret and the provided opts. (Under the hood, this is making an adapted
 // call to hotp.GenerateCodeCustom)
-func GenerateCodeWithOpts(secret string, t time.Time, validateOpts ...ValidateOpt) (passcode string, err error) {
+func GenerateCodeWithOpts(secret string, validateOpts ...ValidateOpt) (passcode string, err error) {
 
 	opts := new(ValidateOpts)
 
@@ -110,7 +109,7 @@ func GenerateCodeWithOpts(secret string, t time.Time, validateOpts ...ValidateOp
 	}
 	opts.defaultOpts()
 
-	counter := uint64(math.Floor(float64(t.Unix()) / float64(opts.Period)))
+	counter := uint64(math.Floor(float64(opts.t.Unix()) / float64(opts.Period)))
 	passcode, err = hotp.GenerateCodeCustom(secret, counter, hotp.ValidateOpts{
 		Digits:    opts.Digits,
 		Algorithm: opts.Algorithm,

--- a/totp/totp_opts.go
+++ b/totp/totp_opts.go
@@ -1,0 +1,122 @@
+package totp
+
+import (
+	"math"
+	"net/url"
+	"strconv"
+	"time"
+
+	"github.com/pquerna/otp"
+	"github.com/pquerna/otp/hotp"
+)
+
+// ValidateWithOpts validate with opts
+// it has deprecated Validate and will replace it soon.
+func ValidateWithOpts(passcode, secret string, validateOpts ...ValidateOpt) (bool, error) {
+	return validateCustomOpt(passcode, secret, time.Now(), validateOpts...)
+}
+
+// validateCustomOpt validates a TOTP given a user specified time and custom options.
+// Most users should use Validate() to provide an interpolatable TOTP experience.
+// This replicates ValidateCustomOpt
+func validateCustomOpt(passcode, secret string, t time.Time, validateOpts ...ValidateOpt) (bool, error) {
+
+	opts := new(ValidateOpts)
+
+	for _, opt := range validateOpts {
+		opt(opts)
+	}
+	opts.defaultOpts()
+
+	counters := []uint64{}
+	counter := int64(math.Floor(float64(t.Unix()) / float64(opts.Period)))
+
+	counters = append(counters, uint64(counter))
+	for i := 1; i <= int(opts.Skew); i++ {
+		counters = append(counters, uint64(counter+int64(i)))
+		counters = append(counters, uint64(counter-int64(i)))
+	}
+
+	for _, counter := range counters {
+		rv, err := hotp.ValidateCustom(passcode, counter, secret, hotp.ValidateOpts{
+			Digits:    opts.Digits,
+			Algorithm: opts.Algorithm,
+		})
+
+		if err != nil {
+			return false, err
+		}
+
+		if rv {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+//
+
+// GenerateWithOpts a new TOTP Key.
+func GenerateWithOpts(genOpts ...GenerateOpt) (*otp.Key, error) {
+
+	opts := new(GenerateOpts)
+
+	for _, opt := range genOpts {
+		opt(opts)
+	}
+
+	if err := opts.defaults(); err != nil {
+		return nil, err
+	}
+	// otpauth://totp/Example:alice@google.com?secret=JBSWY3DPEHPK3PXP&issuer=Example
+
+	v := url.Values{}
+
+	if opts.Secret != nil {
+		v.Set("secret", b32NoPadding.EncodeToString(opts.Secret))
+	} else {
+		secret := make([]byte, opts.SecretSize)
+		_, err := opts.Rand.Read(secret)
+		if err != nil {
+			return nil, err
+		}
+		v.Set("secret", b32NoPadding.EncodeToString(secret))
+	}
+
+	v.Set("issuer", opts.Issuer)
+	v.Set("period", strconv.FormatUint(uint64(opts.Period), 10))
+	v.Set("algorithm", opts.Algorithm.String())
+	v.Set("digits", opts.Digits.String())
+
+	u := url.URL{
+		Scheme:   "otpauth",
+		Host:     "totp",
+		Path:     "/" + opts.Issuer + ":" + opts.AccountName,
+		RawQuery: v.Encode(),
+	}
+	return otp.NewKeyFromURL(u.String())
+}
+
+// GenerateCodeWithOpts takes a timepoint and produces a passcode using a
+// secret and the provided opts. (Under the hood, this is making an adapted
+// call to hotp.GenerateCodeCustom)
+func GenerateCodeWithOpts(secret string, t time.Time, validateOpts ...ValidateOpt) (passcode string, err error) {
+
+	opts := new(ValidateOpts)
+
+	for _, opt := range validateOpts {
+		opt(opts)
+	}
+	opts.defaultOpts()
+
+	counter := uint64(math.Floor(float64(t.Unix()) / float64(opts.Period)))
+	passcode, err = hotp.GenerateCodeCustom(secret, counter, hotp.ValidateOpts{
+		Digits:    opts.Digits,
+		Algorithm: opts.Algorithm,
+	})
+	if err != nil {
+		return "", err
+	}
+	return passcode, nil
+}

--- a/totp/totp_test.go
+++ b/totp/totp_test.go
@@ -72,7 +72,10 @@ var (
 func TestValidateRFCMatrix(t *testing.T) {
 	for _, tx := range rfcMatrixTCs {
 		valid, err := ValidateCustom(tx.TOTP, tx.Secret, time.Unix(tx.TS, 0).UTC(),
-			WithDigits(otp.DigitsEight), WithAlgorithm(tx.Mode))
+			ValidateOpts{
+				Digits:    otp.DigitsEight,
+				Algorithm: tx.Mode,
+			})
 		require.NoError(t, err,
 			"unexpected error totp=%s mode=%v ts=%v", tx.TOTP, tx.Mode, tx.TS)
 		require.True(t, valid,
@@ -82,9 +85,11 @@ func TestValidateRFCMatrix(t *testing.T) {
 
 func TestGenerateRFCTCs(t *testing.T) {
 	for _, tx := range rfcMatrixTCs {
-		passcode, err := GenerateCodeCustom(tx.Secret,
-			time.Unix(tx.TS, 0).UTC(),
-			WithAlgorithm(tx.Mode), WithDigits(otp.DigitsSix))
+		passcode, err := GenerateCodeCustom(tx.Secret, time.Unix(tx.TS, 0).UTC(),
+			ValidateOpts{
+				Digits:    otp.DigitsEight,
+				Algorithm: tx.Mode,
+			})
 		assert.Nil(t, err)
 		assert.Equal(t, tx.TOTP, passcode)
 	}
@@ -101,7 +106,11 @@ func TestValidateSkew(t *testing.T) {
 
 	for _, tx := range tests {
 		valid, err := ValidateCustom(tx.TOTP, tx.Secret, time.Unix(tx.TS, 0).UTC(),
-			WithDigits(otp.DigitsEight), WithAlgorithm(tx.Mode), WithSkew(1))
+			ValidateOpts{
+				Digits:    otp.DigitsEight,
+				Algorithm: tx.Mode,
+				Skew:      1,
+			})
 		require.NoError(t, err,
 			"unexpected error totp=%s mode=%v ts=%v", tx.TOTP, tx.Mode, tx.TS)
 		require.True(t, valid,
@@ -110,36 +119,36 @@ func TestValidateSkew(t *testing.T) {
 }
 
 func TestGenerate(t *testing.T) {
-	k, err := Generate(
-		WithIssuer("SnakeOil"), WithAccountName("alice@example.com"),
-	)
-
+	k, err := Generate(GenerateOpts{
+		Issuer:      "SnakeOil",
+		AccountName: "alice@example.com",
+	})
 	require.NoError(t, err, "generate basic TOTP")
 	require.Equal(t, "SnakeOil", k.Issuer(), "Extracting Issuer")
 	require.Equal(t, "alice@example.com", k.AccountName(), "Extracting Account Name")
 	require.Equal(t, 32, len(k.Secret()), "Secret is 32 bytes long as base32.")
 
-	k, err = Generate(
-		WithIssuer("SnakeOil"),
-		WithAccountName("alice@example.com"),
-		WithSecretSize(20),
-	)
+	k, err = Generate(GenerateOpts{
+		Issuer:      "SnakeOil",
+		AccountName: "alice@example.com",
+		SecretSize:  20,
+	})
 	require.NoError(t, err, "generate larger TOTP")
 	require.Equal(t, 32, len(k.Secret()), "Secret is 32 bytes long as base32.")
 
-	k, err = Generate(
-		WithIssuer("SnakeOil"),
-		WithAccountName("alice@example.com"),
-		WithSecretSize(13), // anything that is not divisable by 5, really
-	)
+	k, err = Generate(GenerateOpts{
+		Issuer:      "SnakeOil",
+		AccountName: "alice@example.com",
+		SecretSize:  13, // anything that is not divisable by 5, really
+	})
 	require.NoError(t, err, "Secret size is valid when length not divisable by 5.")
 	require.NotContains(t, k.Secret(), "=", "Secret has no escaped characters.")
 
-	k, err = Generate(
-		WithIssuer("SnakeOil"),
-		WithAccountName("alice@example.com"),
-		WithSecret([]byte("helloworld")),
-	)
+	k, err = Generate(GenerateOpts{
+		Issuer:      "SnakeOil",
+		AccountName: "alice@example.com",
+		Secret:      []byte("helloworld"),
+	})
 	require.NoError(t, err, "Secret generation failed")
 	sec, err := b32NoPadding.DecodeString(k.Secret())
 	require.NoError(t, err, "Secret wa not valid base32")


### PR DESCRIPTION
I've been using this package for quite a while and it has helped me thousands of times. However, sometimes I get confused in using custom validators/generators. I think we can make it better if you agree on using options in main functions, say, Validate and Generate funcs.