### PR TITLE
Set default digit value for hotp.GenerateCodeCustom()

### DIFF
--- a/hotp/hotp.go
+++ b/hotp/hotp.go
@@ -71,6 +71,10 @@ func GenerateCode(secret string, counter uint64) (string, error) {
 // GenerateCodeCustom uses a counter and secret value and options struct to
 // create a passcode.
 func GenerateCodeCustom(secret string, counter uint64, opts ValidateOpts) (passcode string, err error) {
+	//Set default value
+	if opts.Digits == 0 {
+		opts.Digits = otp.DigitsSix
+	}
 	// As noted in issue #10 and #17 this adds support for TOTP secrets that are
 	// missing their padding.
 	secret = strings.TrimSpace(secret)

--- a/hotp/hotp_test.go
+++ b/hotp/hotp_test.go
@@ -78,6 +78,19 @@ func TestGenerateRFCMatrix(t *testing.T) {
 	}
 }
 
+func TestGenerateCodeCustom(t *testing.T){
+	secSha1 := base32.StdEncoding.EncodeToString([]byte("12345678901234567890"))
+
+	code, err := GenerateCodeCustom("foo",1,ValidateOpts{})
+	print(code)
+	require.Equal(t, otp.ErrValidateSecretInvalidBase32, err, "Decoding of secret as base32 failed.")
+	require.Equal(t, "", code, "Code should be empty string when we have an error.")
+
+	code, err = GenerateCodeCustom(secSha1,1,ValidateOpts{})
+	require.Equal(t, 6, len(code), "Code should be 6 digits when we have not an error.")
+	require.NoError(t, err, "Expected no error.")
+}
+
 func TestValidateInvalid(t *testing.T) {
 	secSha1 := base32.StdEncoding.EncodeToString([]byte("12345678901234567890"))
 
@@ -85,7 +98,7 @@ func TestValidateInvalid(t *testing.T) {
 		ValidateOpts{
 			Digits:    otp.DigitsSix,
 			Algorithm: otp.AlgorithmSHA1,
-		})
+	})
 	require.Equal(t, otp.ErrValidateInputInvalidLength, err, "Expected Invalid length error.")
 	require.Equal(t, false, valid, "Valid should be false when we have an error.")
 


### PR DESCRIPTION
**Problem:** If the validate` Ops.Digit` parameter is not passed to the `hotp.GenerateCodeCustom()` function, the default value is not correctly assigned. By default, it should generate a **6-digit code**, but it produces **0.**

**Solution:**

- Add unit test for `hotp.GenerateCodeCustom()`
- I set the `otp.DigitSix` value as the default.