### PR TITLE
Feat: Steam TOTP encoding

### DIFF
--- a/hotp/hotp.go
+++ b/hotp/hotp.go
@@ -57,6 +57,8 @@ type ValidateOpts struct {
 	Digits otp.Digits
 	// Algorithm to use for HMAC. Defaults to SHA1.
 	Algorithm otp.Algorithm
+	// Encoder to use for output code.
+	Encoder otp.Encoder
 }
 
 // GenerateCode creates a HOTP passcode given a counter and secret.
@@ -112,15 +114,34 @@ func GenerateCodeCustom(secret string, counter uint64, opts ValidateOpts) (passc
 		(int(sum[offset+3]) & 0xff))
 
 	l := opts.Digits.Length()
-	mod := int32(value % int64(math.Pow10(l)))
+	switch opts.Encoder {
+	case otp.EncoderDefault:
+		mod := int32(value % int64(math.Pow10(l)))
 
-	if debug {
-		fmt.Printf("offset=%v\n", offset)
-		fmt.Printf("value=%v\n", value)
-		fmt.Printf("mod'ed=%v\n", mod)
+		if debug {
+			fmt.Printf("offset=%v\n", offset)
+			fmt.Printf("value=%v\n", value)
+			fmt.Printf("mod'ed=%v\n", mod)
+		}
+		passcode = opts.Digits.Format(mod)
+	case otp.EncoderSteam:
+		// Define the character set used by Steam Guard codes.
+		alphabet := []byte{
+			'2', '3', '4', '5', '6', '7', '8', '9', 'B', 'C',
+			'D', 'F', 'G', 'H', 'J', 'K', 'M', 'N', 'P', 'Q',
+			'R', 'T', 'V', 'W', 'X', 'Y',
+		}
+		radix := int64(len(alphabet))
+
+		for i := 0; i < l; i++ {
+			digit := value % radix
+			value /= radix
+			c := alphabet[digit]
+			passcode += string(c)
+		}
 	}
 
-	return opts.Digits.Format(mod), nil
+	return
 }
 
 // ValidateCustom validates an HOTP with customizable options. Most users should

--- a/otp.go
+++ b/otp.go
@@ -154,12 +154,7 @@ func (k *Key) Digits() Digits {
 	q := k.url.Query()
 
 	if u, err := strconv.ParseUint(q.Get("digits"), 10, 64); err == nil {
-		switch u {
-		case 8:
-			return DigitsEight
-		default:
-			return DigitsSix
-		}
+		return Digits(u)
 	}
 
 	// Six is the most common value.
@@ -180,6 +175,19 @@ func (k *Key) Algorithm() Algorithm {
 		return AlgorithmSHA512
 	default:
 		return AlgorithmSHA1
+	}
+}
+
+// Encoder returns the encoder used or the default ("")
+func (k *Key) Encoder() Encoder {
+	q := k.url.Query()
+
+	a := strings.ToLower(q.Get("encoder"))
+	switch a {
+	case "steam":
+		return EncoderSteam
+	default:
+		return EncoderDefault
 	}
 }
 
@@ -253,3 +261,10 @@ func (d Digits) Length() int {
 func (d Digits) String() string {
 	return fmt.Sprintf("%d", d)
 }
+
+type Encoder string
+
+const (
+	EncoderDefault Encoder = ""
+	EncoderSteam   Encoder = "steam"
+)

--- a/totp/totp.go
+++ b/totp/totp.go
@@ -73,6 +73,8 @@ type ValidateOpts struct {
 	Digits otp.Digits
 	// Algorithm to use for HMAC. Defaults to SHA1.
 	Algorithm otp.Algorithm
+	// Encoder to use for output code.
+	Encoder otp.Encoder
 }
 
 // GenerateCodeCustom takes a timepoint and produces a passcode using a
@@ -86,6 +88,7 @@ func GenerateCodeCustom(secret string, t time.Time, opts ValidateOpts) (passcode
 	passcode, err = hotp.GenerateCodeCustom(secret, counter, hotp.ValidateOpts{
 		Digits:    opts.Digits,
 		Algorithm: opts.Algorithm,
+		Encoder:   opts.Encoder,
 	})
 	if err != nil {
 		return "", err
@@ -113,8 +116,8 @@ func ValidateCustom(passcode string, secret string, t time.Time, opts ValidateOp
 		rv, err := hotp.ValidateCustom(passcode, counter, secret, hotp.ValidateOpts{
 			Digits:    opts.Digits,
 			Algorithm: opts.Algorithm,
+			Encoder:   opts.Encoder,
 		})
-
 		if err != nil {
 			return false, err
 		}

--- a/totp/totp_test.go
+++ b/totp/totp_test.go
@@ -175,3 +175,26 @@ func TestGoogleLowerCaseSecret(t *testing.T) {
 	valid := Validate(code, w.Secret())
 	require.True(t, valid)
 }
+
+func TestSteamSecret(t *testing.T) {
+	w, err := otp.NewKeyFromURL(`otpauth://totp/username%20steam:username?secret=qlt6vmy6svfx4bt4rpmisaiyol6hihca&period=30&digits=5&issuer=username%20steam&encoder=steam`)
+	require.NoError(t, err)
+	require.Equal(t, "qlt6vmy6svfx4bt4rpmisaiyol6hihca", w.Secret())
+	require.Equal(t, otp.EncoderSteam, w.Encoder())
+	require.Equal(t, 5, w.Digits().Length())
+
+	n := time.Now().UTC()
+	opts := ValidateOpts{
+		Period:  uint(w.Period()),
+		Digits:  w.Digits(),
+		Encoder: w.Encoder(),
+	}
+	code, err := GenerateCodeCustom(w.Secret(), n, opts)
+	require.NoError(t, err)
+
+	require.Len(t, code, w.Digits().Length())
+
+	valid, err := ValidateCustom(code, w.Secret(), n, opts)
+	require.NoError(t, err)
+	require.True(t, valid)
+}


### PR DESCRIPTION
This PR adds support for Steam TOTP encoding. totp:// URL should have `encoder=steam` param