### PR TITLE
fix(security): Ensure the entire secret is random

### DIFF
--- a/hotp/hotp.go
+++ b/hotp/hotp.go
@@ -215,7 +215,7 @@ func Generate(opts GenerateOpts) (*otp.Key, error) {
 		v.Set("secret", b32NoPadding.EncodeToString(opts.Secret))
 	} else {
 		secret := make([]byte, opts.SecretSize)
-		_, err := opts.Rand.Read(secret)
+		_, err := io.ReadFull(opts.Rand, secret)
 		if err != nil {
 			return nil, err
 		}

--- a/totp/totp.go
+++ b/totp/totp.go
@@ -187,7 +187,7 @@ func Generate(opts GenerateOpts) (*otp.Key, error) {
 		v.Set("secret", b32NoPadding.EncodeToString(opts.Secret))
 	} else {
 		secret := make([]byte, opts.SecretSize)
-		_, err := opts.Rand.Read(secret)
+		_, err := io.ReadFull(opts.Rand, secret)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
The generated OTP secret can loose entropy due to incomplete reads from the underlying random generator.
Use `io.ReadFull` to ensure the entire secret buffer is replaced.