### PR TITLE
Fix typo in comment

### DIFF
--- a/totp/totp.go
+++ b/totp/totp.go
@@ -139,7 +139,7 @@ type GenerateOpts struct {
 	AccountName string
 	// Number of seconds a TOTP hash is valid for. Defaults to 30 seconds.
 	Period uint
-	// Size in size of the generated Secret. Defaults to 20 bytes.
+	// Size in bytes of the generated Secret. Defaults to 20 bytes.
 	SecretSize uint
 	// Secret to store. Defaults to a randomly generated secret of SecretSize.  You should generally leave this empty.
 	Secret []byte


### PR DESCRIPTION
`SecretSize` is used to initialized an array of that size:
https://github.com/pquerna/otp/blob/5971b1ef1d6652fec2caed37f11e5cacd9249f78/totp/totp.go#L189